### PR TITLE
独自ドメインを許可ホストに追加する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,6 +94,7 @@ Rails.application.configure do
   # ]
   config.hosts = [
     /.*\.run\.app/,
+    "app.juneboku.xyz",
   ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }


### PR DESCRIPTION
独自ドメインを設定してから Production 環境のアプリケーションにアクセスしてみたら 403 が返ってきて、

```
2024-05-04 23:15:51.267 JST
GET403649 B2 msChrome 124 https://app.juneboku.xyz/

2024-05-04 23:15:51.275 JST
E, [2024-05-04T14:15:51.276627 #7] ERROR -- : [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: app.juneboku.xyz
```

ログを見てみたら `Blocked hosts: app.juneboku.xyz` と出ていた。ああ、許可ホストの設定をしなきゃですな〜。
