### PR TITLE
ロギングをどうするかを指定しないとビルドが失敗するみたい

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,3 +5,5 @@ steps:
     args: ['push', 'gcr.io/$PROJECT_ID/app-juneboku-xyz:$COMMIT_SHA']
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['run', 'deploy', 'app-juneboku-xyz', '--image', 'gcr.io/$PROJECT_ID/app-juneboku-xyz:$COMMIT_SHA', '--region', 'asia-northeast1', '--allow-unauthenticated']
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
- https://github.com/junebako/app.juneboku.xyz/pull/19

の内容でビルドがどうなるかを試してみたら、

```
Your build failed to run: generic::invalid_argument: if 'build.service_account' is specified, the build must either (a) specify 'build.logs_bucket', (b) use the REGIONAL_USER_OWNED_BUCKET build.options.default_logs_bucket_behavior option, or (c) use either CLOUD_LOGGING_ONLY / NONE logging options
```

と言われて失敗してしまった。示された中の(c)に当たる方法を採用してみる。
