### PR TITLE
Productionではリダイレクト先のlocationが空になってしまったので、別実装を試す

### DIFF
--- a/lib/nikki.rb
+++ b/lib/nikki.rb
@@ -14,7 +14,7 @@ class Nikki
 
     raise Nikki::NotFound if page.nil?
 
-    page.url = "https://scrapbox.io/#{@project_name}/" + page.titleLc
+    page.url = "https://scrapbox.io/#{@project_name}/" + URI.encode_uri_component(page.title)
     page
   end
 


### PR DESCRIPTION
- https://github.com/junebako/app.juneboku.xyz/pull/22

はDevelopment環境では期待した通りに動いていたんだけど、Productionにデプロイしてみたら、レスポンスが302にはなるが真っ白なページが表示されてリダイレクトはされない、という挙動になってしまった。なんでだろう :thinking:

```
$ curl -i https://app.juneboku.xyz/nikki/2024-05-19

HTTP/2 302
x-frame-options: SAMEORIGIN
x-xss-protection: 0
x-content-type-options: nosniff
x-permitted-cross-domain-policies: none
referrer-policy: strict-origin-when-cross-origin
content-type: text/html; charset=utf-8
cache-control: no-cache
x-request-id: 9400d2e5-d947-4c09-9c7e-6c1d68b77037
x-runtime: 0.495242
strict-transport-security: max-age=63072000; includeSubDomains
x-cloud-trace-context: 964192fae931672ff55679b884b965ea
date: Sun, 19 May 2024 14:37:22 GMT
server: Google Frontend
content-length: 0
via: 1.1 google, 1.1 google
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

curlで見てみると、リダイレクト先となるlocationが存在していないようだった。もしかしたらリダイレクト先に指定したURLがinvalidなのかもしれない、と思いURLエンコードした値を試してみることにする。
